### PR TITLE
Add Ansible configuration for Bastion host as Proxy

### DIFF
--- a/Ansible/Bastion_as_Proxy/.gitignore
+++ b/Ansible/Bastion_as_Proxy/.gitignore
@@ -1,0 +1,22 @@
+# Ansible Vault encrypted files
+group_vars/*/vault.yml
+
+# Vault password files
+.vault_pass
+.vault_pass.txt
+vault_pass.txt
+
+# Temporary files
+*.tmp
+*.swp
+*~
+
+# Python cache
+__pycache__/
+*.pyc
+
+# Ansible retry files
+*.retry
+
+# Local test files
+test_*.yml

--- a/Ansible/Bastion_as_Proxy/README.md
+++ b/Ansible/Bastion_as_Proxy/README.md
@@ -1,0 +1,264 @@
+# Using WALLIX Bastion as SSH Proxy
+
+This example demonstrates how to use a WALLIX Bastion as an SSH proxy (jump host) to connect to remote machines.
+
+## Overview
+
+Instead of connecting directly to target servers, traffic is routed through the WALLIX Bastion using its built-in proxy mechanism:
+
+```ini
+Ansible Controller → WALLIX Bastion (Proxy) → Target Server
+```
+
+**WALLIX Proxy Syntax:**
+
+WALLIX uses a special SSH connection format:
+
+```ini
+target_user@target_host@domain:service:account:bastion_user@bastion_ip
+```
+
+Example: `root@local@server1:SSH:my_authorization:piviledgeuser@192.168.1.75`
+
+Where:
+
+- `root` = user on the target server
+- `local` = WALLIX domain of the target
+- `server1` = target server name in WALLIX
+- `SSH` = service
+- `my_authorization` = WALLIX account name
+- `piviledgeuser` = bastion user (for proxy authentication)
+- `192.168.1.75` = bastion IP
+
+**Important:** WALLIX Bastion has two different access methods:
+
+- **Administrative access:** Port 2242 with `wabadmin` (for managing the bastion itself)
+- **Proxy access:** Port 22 with special syntax (for accessing target servers through the bastion)
+
+This approach:
+
+- Centralizes access control through the bastion
+- Eliminates need for direct network access to target servers
+- Maintains comprehensive audit trail through WALLIX
+- Uses WALLIX's built-in connection routing
+
+## Prerequisites
+
+- WALLIX Bastion accessible from Ansible controller
+- Target servers configured in WALLIX Bastion
+- Bastion user credentials (e.g., `piviledgeuser`) with appropriate permissions
+- WALLIX domain, service, and account names
+
+## Configuration
+
+### Understanding WALLIX Connection String
+
+The connection format is:
+
+```ini
+target_user@target_host@domain:service:account:bastion_user@bastion_ip
+```
+
+You need to know:
+
+1. **Target credentials** - User and IP of the server you want to reach
+2. **WALLIX configuration** - Domain name (e.g., `local`), service (e.g., `SSH`), account name (e.g., `my_authorization`)
+3. **Bastion credentials** - User (e.g., `piviledgeuser`) and IP of the bastion
+
+### Inventory Setup
+
+**inventory.ini:**
+
+```ini
+[bastion]
+# Direct administrative access to the bastion (management interface)
+wallix-bastion ansible_host=192.168.1.75 ansible_port=2242 ansible_user=wabadmin
+
+# Example: root@local@target1:SSH:my_authorization:piviledgeuser@192.168.1.75
+[remote_servers]
+# Target servers behind the bastion using WALLIX proxy syntax
+# WALLIX Format: <targetACCOUNT>@<DOMAIN>@<DEVICE_NAME>:<SERVICE>:<AUTHORIZATION>:<MY_ID>@<BASTION_IP>
+# - DOMAIN: domaine au sens bastion (ex: local)
+# - DEVICE_NAME: nom de la machine cible dans le bastion (ex: target1)
+# Example: root@local@target1:SSH:my_authorization:piviledgeuser@192.168.1.75
+remote-server-1 ansible_host='target1_account@local@target1:SSH:my_authorization:piviledgeuser@192.168.1.75' ansible_port=22
+remote-server-2 ansible_host='target2_account@local@target2:SSH:my_authorization:piviledgeuser@192.168.1.75' ansible_port=22
+
+[remote_servers:vars]
+# WALLIX proxy configuration - NO ProxyCommand needed!
+# The special WALLIX syntax in ansible_host handles everything
+ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+
+```
+
+### Ansible Vault for Credentials
+
+Create vault for bastion admin password:
+
+```bash
+mkdir -p group_vars/bastion
+
+# Create vault for bastion credentials
+ansible-vault create group_vars/bastion/vault.yml
+```
+
+Add to `group_vars/bastion/vault.yml`:
+
+```yaml
+---
+vault_bastion_password: "your_wabadmin_password"
+```
+
+Create `group_vars/bastion/vars.yml`:
+
+```yaml
+---
+ansible_password: "{{ vault_bastion_password }}"
+```
+
+Create vault for WALLIX proxy user password:
+
+```bash
+mkdir -p group_vars/remote_servers
+ansible-vault create group_vars/remote_servers/vault.yml
+```
+
+Add to `group_vars/remote_servers/vault.yml`:
+
+```yaml
+---
+# Password for the bastion user (piviledgeuser) used in proxy connection
+vault_proxy_password: "your_bastion_user_password"
+```
+
+Create `group_vars/remote_servers/vars.yml`:
+
+```yaml
+---
+# Password used for WALLIX proxy authentication
+ansible_password: "{{ vault_proxy_password }}"
+```
+
+**Note:** The `ansible_password` for remote_servers is the bastion user password (`piviledgeuser`), not the target server password. WALLIX handles the target server authentication.
+
+## Usage Examples
+
+### Basic Connection Test
+
+```bash
+# Test bastion administrative connection
+ansible bastion -i inventory.ini -m ping --ask-vault-pass
+
+# Test remote servers through WALLIX proxy
+ansible remote_servers -i inventory.ini -m ping --ask-vault-pass
+```
+
+### Manual SSH Test
+
+Test the WALLIX proxy syntax manually:
+
+```bash
+# Test de connexion au bastion (accès proxy)
+# Format: <targetACCOUNT>@<DOMAIN>@<DEVICE_NAME>:<SERVICE>:<AUTHORIZATION>:<MY_ID>@<BASTION_IP>
+ssh -p 22 'root@local@target1:SSH:my_authorization:piviledgeuser@192.168.1.75' -o StrictHostKeyChecking=no whoami
+```
+
+### Run Playbook
+
+```bash
+ansible-playbook -i inventory.ini proxy_example.yml --ask-vault-pass
+```
+
+## Advanced: Mixed Environment Configuration
+
+For environments where only some hosts are behind WALLIX:
+
+**inventory.ini:**
+
+```ini
+[bastion]
+wallix-bastion ansible_host=192.168.1.75 ansible_port=2242 ansible_user=wabadmin
+
+[behind_wallix]
+# Servers accessible through WALLIX proxy
+server1 ansible_host='root@local@server1:SSH:my_authorization:piviledgeuser@192.168.1.75' ansible_user=root ansible_port=22
+server2 ansible_host='root@local@server2:SSH:my_authorization:piviledgeuser@192.168.1.75' ansible_user=root ansible_port=22
+
+[behind_wallix:vars]
+ansible_connection=ssh
+ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+[direct_access]
+# Directly accessible servers (no WALLIX proxy)
+server3 ansible_host=203.0.113.10 ansible_user=admin
+```
+
+## Troubleshooting
+
+### Connection Timeout
+
+Increase SSH timeout:
+
+```ini
+[remote_servers:vars]
+ansible_ssh_common_args='-o ConnectTimeout=30 -o StrictHostKeyChecking=no'
+
+ansible_ssh_common_args='-o ConnectTimeout=30 -o ProxyCommand="ssh -W %h:%p -p 22 piviledgeuser@192.168.1.75"'
+```
+
+### Authentication Issues
+
+Test manual SSH connection with WALLIX syntax:
+
+```bash
+# Test bastion administrative access
+ssh -p 2242 wabadmin@192.168.1.75
+
+# Test WALLIX proxy connection
+ssh -p 22 'root@local@target1:SSH:my_authorization:piviledgeuser@192.168.1.75'
+# You'll be prompted for the piviledgeuser (bastion user) password
+```
+
+### Invalid Target Error
+
+If you get "Invalid target", verify:
+
+- The WALLIX connection string format is correct
+- The domain name (`local`), service (`SSH`), and account name (`my_authorization`) match your WALLIX configuration
+- The target server is configured in WALLIX with proper access rights
+
+### Wrong Password Prompt
+
+Remember:
+
+- For direct bastion access (port 2242): use `wabadmin` password
+- For WALLIX proxy (port 22 with special syntax): use bastion user password (`piviledgeuser`)
+- WALLIX handles authentication to the target server automatically
+
+### Debug Mode
+
+Run with verbose output:
+
+```bash
+ansible-playbook -i inventory.ini proxy_example.yml --ask-vault-pass -vvvv
+```
+
+## Security Considerations
+
+- Store all passwords in Ansible Vault
+- Use SSH keys when possible instead of passwords
+- Configure `StrictHostKeyChecking=yes` in production (shown as `no` for examples)
+- Regularly rotate credentials
+- Monitor bastion logs for unauthorized access attempts
+
+## Files
+
+- `inventory.ini` - Example inventory with proxy configuration
+- `proxy_example.yml` - Example playbook using bastion as proxy
+- `group_vars/` - Vault-encrypted credentials
+
+## References
+
+- [Ansible SSH Connection](https://docs.ansible.com/ansible/latest/plugins/connection/ssh.html)
+- [SSH ProxyCommand](https://man.openbsd.org/ssh_config#ProxyCommand)
+- [SSH ProxyJump](https://man.openbsd.org/ssh_config#ProxyJump)

--- a/Ansible/Bastion_as_Proxy/create-vault.sh
+++ b/Ansible/Bastion_as_Proxy/create-vault.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+#
+# Create Ansible Vault for Bastion Proxy Setup
+#
+
+set -e
+
+echo "============================================"
+echo "  WALLIX Bastion Proxy - Vault Setup"
+echo "============================================"
+echo ""
+
+# Check if ansible-vault is available
+if ! command -v ansible-vault &> /dev/null; then
+    echo "Error: ansible-vault not found. Please install Ansible first."
+    exit 1
+fi
+
+# Create group_vars directory structure
+echo "Creating directory structure..."
+mkdir -p group_vars/bastion
+mkdir -p group_vars/remote_servers
+
+# Prompt for passwords
+echo ""
+echo "Enter credentials:"
+echo ""
+read -r -p "WALLIX Bastion admin (wabadmin) password: " -s BASTION_PASS
+echo ""
+read -r -p "WALLIX proxy user (admin) password: " -s PROXY_PASS
+echo ""
+echo ""
+
+# Create bastion vault file content
+BASTION_VAULT_CONTENT="---
+# WALLIX Bastion Credentials
+vault_bastion_password: \"$BASTION_PASS\"
+"
+
+# Create bastion vars file
+BASTION_VARS_CONTENT="---
+# WALLIX Bastion Variables
+ansible_password: \"{{ vault_bastion_password }}\"
+"
+
+# Create remote servers vault file content
+REMOTE_VAULT_CONTENT="---
+# WALLIX Proxy User Credentials
+# This is the password for the bastion user (e.g., admin) used in proxy connections
+vault_proxy_password: \"$PROXY_PASS\"
+"
+
+# Create remote servers vars file
+REMOTE_VARS_CONTENT="---
+# Remote Servers Variables
+# Password for WALLIX proxy authentication (bastion user password)
+ansible_password: \"{{ vault_proxy_password }}\"
+"
+
+# Write bastion vars file (unencrypted)
+echo "$BASTION_VARS_CONTENT" > group_vars/bastion/vars.yml
+echo "✓ Created group_vars/bastion/vars.yml"
+
+# Write remote servers vars file (unencrypted)
+echo "$REMOTE_VARS_CONTENT" > group_vars/remote_servers/vars.yml
+echo "✓ Created group_vars/remote_servers/vars.yml"
+
+# Create temporary files with vault content
+TEMP_BASTION=$(mktemp)
+TEMP_REMOTE=$(mktemp)
+echo "$BASTION_VAULT_CONTENT" > "$TEMP_BASTION"
+echo "$REMOTE_VAULT_CONTENT" > "$TEMP_REMOTE"
+
+# Encrypt vault files
+echo ""
+echo "Now you will be prompted to create a vault password."
+echo "This password will be used to encrypt/decrypt all credentials."
+echo ""
+
+# Encrypt bastion vault
+ansible-vault encrypt "$TEMP_BASTION" --output=group_vars/bastion/vault.yml
+echo "✓ Created group_vars/bastion/vault.yml (encrypted)"
+
+# Encrypt remote servers vault with same password
+ansible-vault encrypt "$TEMP_REMOTE" --output=group_vars/remote_servers/vault.yml
+echo "✓ Created group_vars/remote_servers/vault.yml (encrypted)"
+
+# Clean up
+rm -f "$TEMP_BASTION" "$TEMP_REMOTE"
+
+echo ""
+echo "============================================"
+echo "  Vault created successfully!"
+echo "============================================"
+echo ""
+echo "Files created:"
+echo "  - group_vars/bastion/vault.yml (encrypted)"
+echo "  - group_vars/bastion/vars.yml (references)"
+echo "  - group_vars/remote_servers/vault.yml (encrypted)"
+echo "  - group_vars/remote_servers/vars.yml (references)"
+echo ""
+echo "Usage:"
+echo "  # Test bastion administrative connection"
+echo "  ansible bastion -i inventory.ini -m ping --ask-vault-pass"
+echo ""
+echo "  # Test WALLIX proxy connection to remote servers"
+echo "  ansible remote_servers -i inventory.ini -m ping --ask-vault-pass"
+echo ""
+echo "  # Test manual SSH with WALLIX syntax"
+echo "  ssh -p 22 'root@10.0.1.10@z4g4:SSH:test:admin@192.168.1.75'"
+echo ""
+echo "  # Run full playbook"
+echo "  ansible-playbook -i inventory.ini proxy_example.yml --ask-vault-pass"
+echo ""
+echo "To view vault contents:"
+echo "  ansible-vault view group_vars/bastion/vault.yml"
+echo "  ansible-vault view group_vars/remote_servers/vault.yml"
+echo ""
+echo "To edit vault:"
+echo "  ansible-vault edit group_vars/bastion/vault.yml"
+echo "  ansible-vault edit group_vars/remote_servers/vault.yml"
+echo ""

--- a/Ansible/Bastion_as_Proxy/inventory.ini
+++ b/Ansible/Bastion_as_Proxy/inventory.ini
@@ -1,0 +1,18 @@
+[bastion]
+# Direct administrative access to the bastion (management interface)
+wallix-bastion ansible_host=192.168.1.75 ansible_port=2242 ansible_user=wabadmin
+
+# Example: root@z4g4@local:SSH:my_authorization:admin@192.168.1.75
+[remote_servers]
+# Target servers behind the bastion using WALLIX proxy syntax
+# WALLIX Format: <targetACCOUNT>@<DOMAIN>@<DEVICE_NAME>:<SERVICE>:<AUTHORIZATION>:<MY_ID>@<BASTION_IP>
+# - DOMAIN: domaine au sens bastion (ex: local)
+# - DEVICE_NAME: nom de la machine cible dans le bastion (ex: target1)
+# Example: root@local@target1:SSH:my_authorization:bastion_user@ip_bastion
+remote-server-1 ansible_host='target1_account@local@target1:SSH:my_authorization:bastion_user@192.168.1.75' ansible_port=22
+remote-server-2 ansible_host='target2_account@local@target2:SSH:my_authorization:admin@192.168.1.75' ansible_port=22
+
+[remote_servers:vars]
+# WALLIX proxy configuration - NO ProxyCommand needed!
+# The special WALLIX syntax in ansible_host handles everything
+ansible_ssh_common_args='-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'

--- a/Ansible/Bastion_as_Proxy/proxy_example.yml
+++ b/Ansible/Bastion_as_Proxy/proxy_example.yml
@@ -1,0 +1,71 @@
+---
+- name: Test connection through WALLIX Bastion proxy
+  hosts: remote_servers
+  gather_facts: yes
+
+  tasks:
+    - name: Ping remote servers
+      ping:
+      register: ping_result
+
+    - name: Display connection success
+      debug:
+        msg: "Successfully connected to {{ inventory_hostname }} through bastion"
+
+    - name: Get hostname
+      command: hostname
+      register: hostname_result
+
+    - name: Display hostname
+      debug:
+        msg: "Remote hostname: {{ hostname_result.stdout }}"
+
+    - name: Check uptime
+      command: uptime
+      register: uptime_result
+
+    - name: Display uptime
+      debug:
+        msg: "{{ uptime_result.stdout }}"
+
+    - name: Gather system information
+      setup:
+        filter: ansible_distribution*
+
+    - name: Display OS information
+      debug:
+        msg:
+          - "OS: {{ ansible_distribution }} {{ ansible_distribution_version }}"
+          - "Architecture: {{ ansible_architecture }}"
+
+    - name: Create test file
+      copy:
+        content: |
+          This file was created via WALLIX Bastion proxy
+          Date: {{ ansible_date_time.iso8601 }}
+          From: {{ ansible_hostname }}
+        dest: /tmp/bastion_proxy_test.txt
+        mode: '0644'
+
+    - name: Read test file
+      command: cat /tmp/bastion_proxy_test.txt
+      register: file_content
+
+    - name: Display file content
+      debug:
+        msg: "{{ file_content.stdout_lines }}"
+
+    - name: Clean up test file
+      file:
+        path: /tmp/bastion_proxy_test.txt
+        state: absent
+
+- name: Summary
+  hosts: remote_servers
+  gather_facts: no
+
+  tasks:
+    - name: Display summary
+      debug:
+        msg: "All {{ ansible_play_hosts | length }} remote servers accessed successfully through WALLIX Bastion"
+      run_once: true


### PR DESCRIPTION
- Create base configuration files for using a Bastion host as a proxy
- Include README documentation
- Add vault creation script
- Create example playbook and inventory structure
- Add gitignore for vault secrets